### PR TITLE
add: hide the floating cart button to hide the product section

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -8,7 +8,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import useObserverComponent from "../../hooks/useObserverComponent";
 import { useAuth } from "../../context/AuthProvider";
-import CartBadge from "../CartBadge";
+//import CartBadge from "../CartBadge";
 
 export const Header = () => {
   const [isChecked, setIsChecked] = useState(false);
@@ -145,7 +145,8 @@ export const Header = () => {
             ) : null}
           </li>
         </ul>
-        <CartBadge />
+        {/* Se oculta el badge del carrito por el momento */}
+        {/* <CartBadge /> */}
       </nav>
     </header>
   );

--- a/src/layout/index.jsx
+++ b/src/layout/index.jsx
@@ -2,7 +2,7 @@ import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import "./mainLayout.scss";
 import PropTypes from "prop-types";
-import CartBadge from "../components/CartBadge";
+//import CartBadge from "../components/CartBadge";
 import CheckoutModal from "../components/CheckoutModal/CheckoutModal";
 import { useOrder } from "../context/orderContext";
 
@@ -11,7 +11,8 @@ export const MainLayout = ({ children }) => {
   return (
     <div className="main">
       <Header />
-      <CartBadge />
+      {/* Se oculta el badge del carrito por el momento */}
+      {/* <CartBadge /> */}
       <section className="mainContainer">{children}</section>
       <CheckoutModal open={modalIsOpen} hideModal={hideModal}/>
 


### PR DESCRIPTION
Se ocultó el botón flotante del carrito para evitar la entrada a la sección del carrito/productos. 
Solamente se comentó el código para no eliminarlo por si se necesita reutilizar en un futuro. 

Antes: 
<img width="1914" height="913" alt="image" src="https://github.com/user-attachments/assets/d3f059e4-7cfd-421d-968c-09b5695191b1" />


Ahora: 
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/5e9b965f-b60e-4231-817b-734804127aaf" />

Link airtable asociado: [Ocultar ecommerce](https://airtable.com/app1dRELIjLmNCLLd/tbliBTcxSBQXntm2b/viwbub1gwVOKiI03s/recjtnXexg6Vwpcd5?blocks=hide)
