### PR TITLE
fix margin collaborator

### DIFF
--- a/src/views/Form/forms.scss
+++ b/src/views/Form/forms.scss
@@ -4,7 +4,6 @@
 .titlesFormsContainer {
   text-align: center;
   padding: 7rem 1rem;
-  margin-top: 10rem;
   
   
   @include tablet {


### PR DESCRIPTION
Arregla el margin-top del formulario colaboradores.
Antes 
<img width="447" height="565" alt="image" src="https://github.com/user-attachments/assets/3b09de1c-5574-4ea6-a4d6-5d47827c46aa" />
Despues 
<img width="460" height="566" alt="image" src="https://github.com/user-attachments/assets/a10c60a4-55a1-4f19-8703-cd21326230c7" />

