### PR TITLE
fix: donors section

### DIFF
--- a/src/views/Done/done.scss
+++ b/src/views/Done/done.scss
@@ -35,7 +35,6 @@
     min-width: 20vw;
     border-radius: 7%;
     position: absolute;
-    left: 1rem;
     z-index: 1;
 
     @include desktop{


### PR DESCRIPTION
# Seccion Donaciones

- Se centro el texto y el boton

Version original:
<img width="1769" height="580" alt="image" src="https://github.com/user-attachments/assets/eb70edca-35ee-4eb8-92fa-222115570755" />

Version con los cambios aplicados:
<img width="1776" height="552" alt="image" src="https://github.com/user-attachments/assets/f57815c3-15c6-42ff-8108-047f8a29fda3" />


[Tarea de airtable](https://airtable.com/app1dRELIjLmNCLLd/tbliBTcxSBQXntm2b/viwbub1gwVOKiI03s/recvsMsq8KBwNIRS3?blocks=hide)
